### PR TITLE
add config to reuse port connection

### DIFF
--- a/conf.js
+++ b/conf.js
@@ -13,6 +13,10 @@ function mergeExports(anotherModule){
 exports.port = null;
 //exports.port = 6611;
 
+// enable this will make websocket server doesn't spawn on new port
+// this is usefull if you already have SocketServer running and want to reuse the port
+//exports.portReuse = true;
+
 // how peers connect to me
 //exports.myUrl = 'wss://example.org/bb';
 

--- a/network.js
+++ b/network.js
@@ -2886,6 +2886,23 @@ function onWebsocketMessage(message) {
 	}
 }
 
+// @see https://www.npmjs.com/package/ws#multiple-servers-sharing-a-single-https-server
+function handleUpgradeConnection(incomingRequest, socket, head) {
+	if (!(wss instanceof WebSocketServer)) throw new Error('reuse port and upgrade connection in light node is not supported')
+
+	if (incomingRequest instanceof require('net').Server && !socket && !head) {
+		incomingRequest.on('upgrade', function(_request, _socket, _head) {
+			upgrade(_request, _socket, _head)
+		})
+	} else upgrade(incomingRequest, socket, head)
+
+	function upgrade($request, $socket, $head) {
+		wss.handleUpgrade($request, $socket, $head, function(ws) {
+			wss.emit('connection', ws, request);
+		})
+	}
+}
+
 function startAcceptingConnections(){
 	db.query("DELETE FROM watched_light_addresses");
 	db.query("DELETE FROM watched_light_units");
@@ -2893,7 +2910,7 @@ function startAcceptingConnections(){
 	setInterval(unblockPeers, 10*60*1000);
 	initBlockedPeers();
 	// listen for new connections
-	wss = new WebSocketServer({ port: conf.port });
+	wss = new WebSocketServer(conf.portReuse ? { noServer: true } : { port: conf.port });
 	wss.on('connection', function(ws) {
 		var ip = ws.upgradeReq.connection.remoteAddress;
 		if (!ip){
@@ -3040,6 +3057,7 @@ exports.sendRequest = sendRequest;
 exports.sendResponse = sendResponse;
 exports.findOutboundPeerOrConnect = findOutboundPeerOrConnect;
 exports.handleOnlineJoint = handleOnlineJoint;
+exports.handleUpgradeConnection = handleUpgradeConnection
 
 exports.handleOnlinePrivatePayment = handleOnlinePrivatePayment;
 exports.requestUnfinishedPastUnitsOfPrivateChains = requestUnfinishedPastUnitsOfPrivateChains;


### PR DESCRIPTION
> TL;DR see https://www.npmjs.com/package/ws#multiple-servers-sharing-a-single-https-server

I intend to create this PR because I need the ability to run my bot on Heroku ([example](https://github.com/heroku-examples/node-ws-test/blob/master/index.js), Heroku only expose 1 port and it needs to bind an http server) but seems I was mistaken. I thought in light node mode, it will run WebSocket server but after looking at the source code I realize it only runs WebSocket client.

Anyway, I will leave it here in case you find this handy. Especially if someone want to support/experiment with other socket server/broker 🙂.

<details><summary><b>How to use</b></summary>

Given `conf.js`:
```js
exports.reusePort = true
```

If someone want to share port with an http server:
```js
const http = require('http');

const server = http.createServer();
const wss = new WebSocket.Server({ server });

require('byteballcore/network').handleUpgradeConnection(server)

server.listen(80);
```

Otherwise, for someone who have their own [socket server](https://nodejs.org/docs/latest/api/net.html#net_class_net_server) implementation:
```js
const Broker = require('custom-broker');
const {handleUpgradeConnection} = require('byteballcore/network');

const server = new Broker();

server.upgrade(
  (request, socket, head) => handleUpgradeConnection(request, socket, head)
);

server.bind(6331)
```
</details>

#### Other references
- [just some of my experiment](https://github.com/DrSensor/example-rpcserver-on-browser/blob/c790bc32566bca12747608d9e7a804a8410ce5d2/src/controller/rpc/index.ts#L44) (written in typescript)
- [multi-rpc](https://www.npmjs.com/package/multi-rpc)