### PR TITLE
Disable side-effect import via conf.js

### DIFF
--- a/conf.js
+++ b/conf.js
@@ -7,6 +7,9 @@ function mergeExports(anotherModule){
 		exports[key] = anotherModule[key];
 }
 
+// start node explicitly by `require('ocore/network').start()`
+//exports.explicitStart = true
+
 // port we are listening on.  Set to null to disable accepting connections
 // recommended port for livenet: 6611
 // recommended port for testnet: 16611

--- a/network.js
+++ b/network.js
@@ -3026,7 +3026,9 @@ function isCatchingUp(){
 	return bCatchingUp;
 }
 
-start();
+if (!conf.explicitStart) {
+	start();
+}
 
 exports.start = start;
 exports.postJointToLightVendor = postJointToLightVendor;


### PR DESCRIPTION
Any reason why you need to start the node immediately at require/import?

(I'm bit confused because it explicitly export the start function)
https://github.com/byteball/ocore/blob/6baed87ff6e5135bf626e7d5c40d3f08622b6a1d/network.js#L3031