### PR TITLE
fix startup error from a child dir in windows

### DIFF
--- a/desktop_app.js
+++ b/desktop_app.js
@@ -19,7 +19,7 @@ function getPackageJsonDir(start_dir){
 	}
 	catch(e){
 		var parent_dir = path.dirname(start_dir);
-		if (parent_dir === '/' || process.platform === 'win32' && parent_dir.match(/^\w:[\/\\]/))
+		if (parent_dir === '/' || process.platform === 'win32' && parent_dir.match(/^\w:[\/\\]$/))
 			throw Error('no package.json found');
 		return getPackageJsonDir(parent_dir);
 	}


### PR DESCRIPTION
When ocore start from a child directory in windows, it occurs an error 'no package.json found' for the regex has no line end symbol.