### PR TITLE
[OB-18] Rocks and formulas change parser error message

### DIFF
--- a/aa_validation.js
+++ b/aa_validation.js
@@ -573,7 +573,7 @@ function validateAADefinition(arrDefinition, callback) {
 			complexity = result.complexity;
 			if (result.error) {
 				var errorMessage = "validation of formula " + formula + " failed: " + result.error
-				errorMessage += result.errorContext ? ' at line ' + result.errorContext.token.line + ' col ' + result.errorContext.token.col : '';
+				errorMessage += result.errorMessage ? `\nparser error: ${result.errorMessage}` : ''
 				return cb(errorMessage);
 			}
 			if (complexity > constants.MAX_COMPLEXITY)

--- a/formula/index.js
+++ b/formula/index.js
@@ -73,7 +73,7 @@ exports.validate = function (opts, callback) {
 		}
 	} catch (e) {
 		console.log('==== parse error', e, e.stack)
-		return callback({error: 'parse error', complexity, errorContext: { token: e.token, offset: e.offset }});
+		return callback({error: 'parse error', complexity, errorMessage: e.message});
 	}
 	
 	var count = 0;

--- a/test/aa.test.js
+++ b/test/aa.test.js
@@ -316,7 +316,37 @@ test('bad formula', t => {
 		]
 	}];
 	aa_validation.validateAADefinition(aa, err => {
-		t.deepEqual(err, 'validation of formula trigger.address[] failed: parse error at line 1 col 16');
+		console.log('err :', err);
+		t.deepEqual(err, `validation of formula trigger.address[] failed: parse error
+parser error: invalid syntax at line 1 col 16:
+
+  trigger.address[
+                 ^
+Unexpected sl token: "["
+`);
+	});
+});
+
+test('bad formula with different validation case', t => {
+	var aa = ['autonomous agent', {
+		messages: [
+			{
+				app: 'payment',
+				payload: {
+					asset: 'base',
+					outputs: [
+						{address: "{trigger .address}", amount: "{trigger.output[[asset=base]] - 500}"}
+					]
+				}
+			}
+		]
+	}];
+	aa_validation.validateAADefinition(aa, err => {
+		t.deepEqual(err, `validation of formula trigger .address failed: parse error
+parser error: invalid syntax at line 1 col 1:
+
+  trigger .address
+  ^`);
 	});
 });
 
@@ -347,7 +377,14 @@ test('bad formula with asset', t => {
 		}
 	}];
 	aa_validation.validateAADefinition(aa, err => {
-		t.deepEqual(err, 'validation of formula trigger.data.auto_destroy[] failed: parse error at line 1 col 27');
+		console.log('err :', err);
+		t.deepEqual(err, `validation of formula trigger.data.auto_destroy[] failed: parse error
+parser error: invalid syntax at line 1 col 27:
+
+  trigger.data.auto_destroy[]
+                            ^
+Unexpected sr token: "]"
+`);
 	});
 });
 


### PR DESCRIPTION
Probably, I better should change returning value format for  `validateAADefinition` from `aa_validation` to keep default error message as simple as possible