### PR TITLE
Add sequence_became_bad event

### DIFF
--- a/light.js
+++ b/light.js
@@ -437,16 +437,15 @@ function emitNewMyTransactions(arrNewUnits){
 	);
 }
 
-function updateAndEmitBadSequence(arrBadSequenceUnits){
-	if (!Array.isArray(arrBadSequenceUnits))
-		return console.log("arrBadSequenceUnits not array");
+function updateAndEmitBadSequenceUnits(arrBadSequenceUnits){
+	if (!ValidationUtils.isNonemptyArray(arrBadSequenceUnits))
+		return console.log("arrBadSequenceUnits not array or empty");
 	db.query("UPDATE units SET sequence='temp-bad' WHERE is_stable=0 AND unit IN (?)", [arrBadSequenceUnits], function(result){
 		db.query(
 			getSqlToFilterMyUnits(arrBadSequenceUnits),
 			function(rows){
-				if (rows.length > 0){
-					eventBus.emit('bad_sequence_units', rows.map(function(row){ return row.unit; }));
-				}
+				if (rows.length > 0)
+					eventBus.emit('sequence_became_bad', rows.map(function(row){ return row.unit; }));
 			});
 	});
 }
@@ -685,5 +684,5 @@ exports.prepareLinkProofs = prepareLinkProofs;
 exports.processLinkProofs = processLinkProofs;
 exports.determineIfHaveUnstableJoints = determineIfHaveUnstableJoints;
 exports.prepareParentsAndLastBallAndWitnessListUnit = prepareParentsAndLastBallAndWitnessListUnit;
-exports.updateAndEmitBadSequence = updateAndEmitBadSequence;
+exports.updateAndEmitBadSequenceUnits = updateAndEmitBadSequenceUnits;
 

--- a/light.js
+++ b/light.js
@@ -452,13 +452,14 @@ function updateAndEmitBadSequenceUnits(arrBadSequenceUnits, retryDelay){
 			setTimeout(function(){
 				updateAndEmitBadSequenceUnits(arrNotSavedUnits, retryDelay*2); // we retry later for units that are not validated and saved yet
 			}, retryDelay);
-		db.query("UPDATE units SET sequence='temp-bad' WHERE is_stable=0 AND unit IN (?)", [arrAlreadySavedUnits], function(){
-			db.query(getSqlToFilterMyUnits(arrAlreadySavedUnits),
-			function(arrMySavedUnits){
-				if (arrMySavedUnits.length > 0)
-					eventBus.emit('sequence_became_bad', arrMySavedUnits.map(function(row){ return row.unit; }));
+		if (arrAlreadySavedUnits.length > 0)
+			db.query("UPDATE units SET sequence='temp-bad' WHERE is_stable=0 AND unit IN (?)", [arrAlreadySavedUnits], function(){
+				db.query(getSqlToFilterMyUnits(arrAlreadySavedUnits),
+				function(arrMySavedUnitsRows){
+					if (arrMySavedUnitsRows.length > 0)
+						eventBus.emit('sequence_became_bad', arrMySavedUnitsRows.map(function(row){ return row.unit; }));
+				});
 			});
-		});
 	});
 }
 

--- a/light.js
+++ b/light.js
@@ -437,6 +437,20 @@ function emitNewMyTransactions(arrNewUnits){
 	);
 }
 
+function updateAndEmitBadSequence(arrBadSequenceUnits){
+	if (!Array.isArray(arrBadSequenceUnits))
+		return console.log("arrBadSequenceUnits not array");
+	db.query("UPDATE units SET sequence='temp-bad' WHERE is_stable=0 AND unit IN (?)", [arrBadSequenceUnits], function(result){
+		db.query(
+			getSqlToFilterMyUnits(arrBadSequenceUnits),
+			function(rows){
+				if (rows.length > 0){
+					eventBus.emit('bad_sequence_units', rows.map(function(row){ return row.unit; }));
+				}
+			});
+	});
+}
+
 
 function prepareParentsAndLastBallAndWitnessListUnit(arrWitnesses, callbacks){
 	if (!ValidationUtils.isArrayOfLength(arrWitnesses, constants.COUNT_WITNESSES))
@@ -671,5 +685,5 @@ exports.prepareLinkProofs = prepareLinkProofs;
 exports.processLinkProofs = processLinkProofs;
 exports.determineIfHaveUnstableJoints = determineIfHaveUnstableJoints;
 exports.prepareParentsAndLastBallAndWitnessListUnit = prepareParentsAndLastBallAndWitnessListUnit;
-
+exports.updateAndEmitBadSequence = updateAndEmitBadSequence;
 

--- a/light.js
+++ b/light.js
@@ -440,14 +440,16 @@ function emitNewMyTransactions(arrNewUnits){
 function updateAndEmitBadSequenceUnits(arrBadSequenceUnits){
 	if (!ValidationUtils.isNonemptyArray(arrBadSequenceUnits))
 		return console.log("arrBadSequenceUnits not array or empty");
-	db.query("UPDATE units SET sequence='temp-bad' WHERE is_stable=0 AND unit IN (?)", [arrBadSequenceUnits], function(result){
-		db.query(
-			getSqlToFilterMyUnits(arrBadSequenceUnits),
-			function(rows){
-				if (rows.length > 0)
-					eventBus.emit('sequence_became_bad', rows.map(function(row){ return row.unit; }));
-			});
-	});
+	setTimeout(function(){ // we add a delay to be sure units had time to be validated and saved
+		db.query("UPDATE units SET sequence='temp-bad' WHERE is_stable=0 AND unit IN (?)", [arrBadSequenceUnits], function(){
+			db.query(
+				getSqlToFilterMyUnits(arrBadSequenceUnits),
+				function(rows){
+					if (rows.length > 0)
+						eventBus.emit('sequence_became_bad', rows.map(function(row){ return row.unit; }));
+				});
+		});
+	}, 500);
 }
 
 

--- a/network.js
+++ b/network.js
@@ -3088,24 +3088,6 @@ function handleRequest(ws, tag, command, params){
 			});
 			break;
 
-		case 'light/get_aa_state_vars':
-			if (conf.bLight)
-				return sendErrorResponse(ws, tag, "I'm light myself, can't serve you");
-			if (ws.bOutbound)
-				return sendErrorResponse(ws, tag, "light clients have to be inbound");
-			if (!params)
-				return sendErrorResponse(ws, tag, "no params in light/get_aa_state_vars");
-			if (!ValidationUtils.isValidAddress(params.address))
-				return sendErrorResponse(ws, tag, "address not valid");
-			storage.readAADefinition(db, params.address, function (arrDefinition) {
-				if (!arrDefinition)
-					return sendErrorResponse(ws, tag, "not an AA");
-				storage.readAAStateVars(params.address, function (objStateVars) {
-					sendResponse(ws, tag, objStateVars);
-				});
-			});
-			break;
-
 		// I'm a hub, the peer wants to enable push notifications
 		case 'hub/enable_notification':
 			if(ws.device_address)

--- a/network.js
+++ b/network.js
@@ -3088,6 +3088,24 @@ function handleRequest(ws, tag, command, params){
 			});
 			break;
 
+		case 'light/get_aa_state_vars':
+			if (conf.bLight)
+				return sendErrorResponse(ws, tag, "I'm light myself, can't serve you");
+			if (ws.bOutbound)
+				return sendErrorResponse(ws, tag, "light clients have to be inbound");
+			if (!params)
+				return sendErrorResponse(ws, tag, "no params in light/get_aa_state_vars");
+			if (!ValidationUtils.isValidAddress(params.address))
+				return sendErrorResponse(ws, tag, "address not valid");
+			storage.readAADefinition(db, params.address, function (arrDefinition) {
+				if (!arrDefinition)
+					return sendErrorResponse(ws, tag, "not an AA");
+				storage.readAAStateVars(params.address, function (objStateVars) {
+					sendResponse(ws, tag, objStateVars);
+				});
+			});
+			break;
+
 		// I'm a hub, the peer wants to enable push notifications
 		case 'hub/enable_notification':
 			if(ws.device_address)

--- a/network.js
+++ b/network.js
@@ -1003,8 +1003,7 @@ function handleJoint(ws, objJoint, bSaved, callbacks){
 						unlock();
 						if (ws)
 							writeEvent((objValidationState.sequence !== 'good') ? 'nonserial' : 'new_good', ws.host);
-						if (objValidationState.sequence === 'good')
-							notifyWatchers(objJoint, ws);
+						notifyWatchers(objJoint, objValidationState.sequence === 'good', ws);
 						if (objValidationState.arrUnitsGettingBadSequence)
 							notifyWatchersAboutUnitsGettingBadSequence(objValidationState.arrUnitsGettingBadSequence);
 						if (!bCatchingUp)
@@ -1353,7 +1352,7 @@ function getAllAuthorsAndOutputsAddresses(objUnit){
 }
 
 // if any of the watched addresses are affected, notifies:  1. own UI  2. light clients
-function notifyWatchers(objJoint, source_ws){
+function notifyWatchers(objJoint, bGoodSequence, source_ws){
 	var bAA = objJoint.new_aa;
 	delete objJoint.new_aa;
 	var objUnit = objJoint.unit;
@@ -1379,7 +1378,7 @@ function notifyWatchers(objJoint, source_ws){
 	
 	if (conf.bLight)
 		return;
-	if (objJoint.ball) // already stable, light clients will require a proof
+	if (objJoint.ball || !bGoodSequence) // If already stable, light clients will require a proof. We notify them only good sequence unit.
 		return;
 	if (!bWatchingForLight)
 		return;
@@ -1608,12 +1607,12 @@ function broadcastJoint(objJoint){
 			if (client.bSubscribed)
 				sendJoint(client, objJoint);
 		});
-	notifyWatchers(objJoint);
+	notifyWatchers(objJoint, true);
 }
 
 function onNewAA(objUnit) {
 	findAndHandleJointsThatAreReady(objUnit.unit);
-	notifyWatchers({ unit: objUnit, new_aa: true });
+	notifyWatchers({ unit: objUnit, new_aa: true }, true);
 }
 
 

--- a/network.js
+++ b/network.js
@@ -1307,30 +1307,37 @@ function notifyWatchersAboutUnitsGettingBadSequence(arrUnits){
 						if (_.intersection(arrMyConcernedAddresses, assocAddressesByUnit[unit]).length > 0)
 							assocUniqueUnits[unit] = true;
 					}
-					eventBus.emit("sequence_became_bad", [Object.keys(assocUniqueUnits)]);
 				}
+				var arrUniqueUnits = Object.keys(assocUniqueUnits);
+				if (arrUniqueUnits.length > 0)
+					eventBus.emit("sequence_became_bad", arrUniqueUnits);
 			}
 		);
 		// notify light watchers
 		if (!bWatchingForLight)
 			return;
-		db.query("SELECT peer,address FROM watched_light_addresses WHERE address IN(?)", [arrConcernedAddresses], function(rows){
-			if (rows.length === 0)
-				return;
+		db.query("SELECT peer,address FROM watched_light_addresses WHERE address IN(?)", [arrConcernedAddresses], function(watched_addresses){
 			var assocUniqueUnitsByPeer = {};
-			rows.forEach(function(row){
+			watched_addresses.forEach(function(row){
 				if (assocUnitsByAddress[row.address]){
-						assocUnitsByAddress[row.address].forEach(function(unit){
+					assocUnitsByAddress[row.address].forEach(function(unit){
 						if (!assocUniqueUnitsByPeer[row.peer])
 							assocUniqueUnitsByPeer[row.peer] = {};
 						assocUniqueUnitsByPeer[row.peer][unit] = true;
 					});
 				}
 			});
-			Object.keys(assocUniqueUnitsByPeer).forEach(function(peer){
-				var ws = getPeerWebSocket(peer);
-				if (ws && ws.readyState === ws.OPEN)
+			db.query("SELECT peer,unit FROM watched_light_units WHERE unit IN(?)", [arrUnits], function(watched_units){
+				watched_units.forEach(function(row){
+					if (!assocUniqueUnitsByPeer[row.peer])
+						assocUniqueUnitsByPeer[row.peer] = {};
+					assocUniqueUnitsByPeer[row.peer][row.unit] = true;
+				});
+				Object.keys(assocUniqueUnitsByPeer).forEach(function(peer){
+					var ws = getPeerWebSocket(peer);
+					if (ws && ws.readyState === ws.OPEN)
 						sendJustsaying(ws, 'light/sequence_became_bad', Object.keys(assocUniqueUnitsByPeer[peer]));
+				});
 			});
 		});
 	});

--- a/storage.js
+++ b/storage.js
@@ -723,6 +723,26 @@ function readAADefinition(conn, address, handleDefinition) {
 	});
 }
 
+function readAAStateVars(address, handle){
+	var options = {};
+	options.gte = "st\n" + address + "\n";
+	options.lte = "st\n" + address + "\n\uFFFF";
+
+	var objStateVars = {}
+	var handleData = function (data){
+		objStateVars[data.key.slice(36)] = data.value;
+	}
+	var kvstore = require('./kvstore.js');
+	var stream = kvstore.createReadStream(options);
+	stream.on('data', handleData)
+	.on('end', function(){
+		handle(objStateVars);
+	})
+	.on('error', function(error){
+		throw Error('error from data stream: '+error);
+	});
+}
+
 function readFreeJoints(ifFoundFreeBall, onDone){
 	db.query("SELECT units.unit FROM units LEFT JOIN archived_joints USING(unit) WHERE is_free=1 AND archived_joints.unit IS NULL", function(rows){
 		async.each(rows, function(row, cb){
@@ -1624,6 +1644,7 @@ exports.readDefinitionChashByAddress = readDefinitionChashByAddress;
 exports.readDefinitionByAddress = readDefinitionByAddress;
 exports.readDefinition = readDefinition;
 exports.readAADefinition = readAADefinition;
+exports.readAAStateVars = readAAStateVars;
 
 exports.readLastMainChainIndex = readLastMainChainIndex;
 

--- a/storage.js
+++ b/storage.js
@@ -723,26 +723,6 @@ function readAADefinition(conn, address, handleDefinition) {
 	});
 }
 
-function readAAStateVars(address, handle){
-	var options = {};
-	options.gte = "st\n" + address + "\n";
-	options.lte = "st\n" + address + "\n\uFFFF";
-
-	var objStateVars = {}
-	var handleData = function (data){
-		objStateVars[data.key.slice(36)] = data.value;
-	}
-	var kvstore = require('./kvstore.js');
-	var stream = kvstore.createReadStream(options);
-	stream.on('data', handleData)
-	.on('end', function(){
-		handle(objStateVars);
-	})
-	.on('error', function(error){
-		throw Error('error from data stream: '+error);
-	});
-}
-
 function readFreeJoints(ifFoundFreeBall, onDone){
 	db.query("SELECT units.unit FROM units LEFT JOIN archived_joints USING(unit) WHERE is_free=1 AND archived_joints.unit IS NULL", function(rows){
 		async.each(rows, function(row, cb){
@@ -1644,7 +1624,6 @@ exports.readDefinitionChashByAddress = readDefinitionChashByAddress;
 exports.readDefinitionByAddress = readDefinitionByAddress;
 exports.readDefinition = readDefinition;
 exports.readAADefinition = readAADefinition;
-exports.readAAStateVars = readAAStateVars;
 
 exports.readLastMainChainIndex = readLastMainChainIndex;
 

--- a/validation.js
+++ b/validation.js
@@ -929,9 +929,12 @@ function validateAuthor(conn, objAuthor, objUnit, objValidationState, callback){
 			if (arrUnstableConflictingUnits.length === 0)
 				return next();
 			// we don't modify the db during validation, schedule the update for the write
-			objValidationState.arrAdditionalQueries.push(
-				{sql: "UPDATE units SET sequence='temp-bad' WHERE unit IN(?) AND +sequence='good'", params: [arrUnstableConflictingUnits]});
-			next();
+			conn.query("SELECT unit FROM units WHERE unit IN(?) AND +sequence='good'",function(rows){
+				objValidationState.arrUnitsGettingBadSequence = rows.map(function(row){return row.unit});
+				objValidationState.arrAdditionalQueries.push(
+					{sql: "UPDATE units SET sequence='temp-bad' WHERE unit IN(?) AND +sequence='good'", params: [arrUnstableConflictingUnits]});
+				next();
+				});
 		});
 	}
 	

--- a/validation.js
+++ b/validation.js
@@ -928,11 +928,12 @@ function validateAuthor(conn, objAuthor, objUnit, objValidationState, callback){
 				return next();
 			if (arrUnstableConflictingUnits.length === 0)
 				return next();
-			// we don't modify the db during validation, schedule the update for the write
-			conn.query("SELECT unit FROM units WHERE unit IN(?) AND +sequence='good'",function(rows){
-				objValidationState.arrUnitsGettingBadSequence = rows.map(function(row){return row.unit});
+			conn.query("SELECT unit FROM units WHERE unit IN(?) AND +sequence='good'",[arrUnstableConflictingUnits],function(rows){
+				if (rows.length > 0)
+					objValidationState.arrUnitsGettingBadSequence = rows.map(function(row){return row.unit});
+				// we don't modify the db during validation, schedule the update for the write
 				objValidationState.arrAdditionalQueries.push(
-					{sql: "UPDATE units SET sequence='temp-bad' WHERE unit IN(?) AND +sequence='good'", params: [arrUnstableConflictingUnits]});
+				{sql: "UPDATE units SET sequence='temp-bad' WHERE unit IN(?) AND +sequence='good'", params: [arrUnstableConflictingUnits]});
 				next();
 				});
 		});

--- a/validation.js
+++ b/validation.js
@@ -930,7 +930,7 @@ function validateAuthor(conn, objAuthor, objUnit, objValidationState, callback){
 				return next();
 			conn.query("SELECT unit FROM units WHERE unit IN(?) AND +sequence='good'",[arrUnstableConflictingUnits],function(rows){
 				if (rows.length > 0)
-					objValidationState.arrUnitsGettingBadSequence = rows.map(function(row){return row.unit});
+					objValidationState.arrUnitsGettingBadSequence = (objValidationState.arrUnitsGettingBadSequence || []).concat(rows.map(function(row){return row.unit}));
 				// we don't modify the db during validation, schedule the update for the write
 				objValidationState.arrAdditionalQueries.push(
 				{sql: "UPDATE units SET sequence='temp-bad' WHERE unit IN(?) AND +sequence='good'", params: [arrUnstableConflictingUnits]});

--- a/wallet.js
+++ b/wallet.js
@@ -136,8 +136,8 @@ function handleJustsaying(ws, subject, body){
 		case 'light/have_updates':
 			lightWallet.refreshLightClientHistory();
 			break;
-		case 'light/have_updates':
-				light.updateAndEmitBadSequence(body);
+		case 'light/sequence_became_bad':
+			light.updateAndEmitBadSequenceUnits(body);
 			break;
 	}
 }

--- a/wallet.js
+++ b/wallet.js
@@ -13,6 +13,7 @@ var storage = require('./storage.js');
 var device = require('./device.js');
 var walletGeneral = require('./wallet_general.js');
 var lightWallet = require('./light_wallet.js');
+var light = require('./light.js');
 var walletDefinedByKeys = require('./wallet_defined_by_keys.js');
 var walletDefinedByAddresses = require('./wallet_defined_by_addresses.js');
 var eventBus = require('./event_bus.js');
@@ -134,6 +135,9 @@ function handleJustsaying(ws, subject, body){
 			
 		case 'light/have_updates':
 			lightWallet.refreshLightClientHistory();
+			break;
+		case 'light/have_updates':
+				light.updateAndEmitBadSequence(body);
 			break;
 	}
 }


### PR DESCRIPTION
This event is emitted when unit(s) that was known as 'good' became 'temp-bad' due to a conflict provoked by a new unit.
The intent is to help the detection of a double-spend attempt, a light node will have to trust that the hub doesn't hide the event.