### PR TITLE
Buffer DeprecationWarning

### DIFF
--- a/chash.js
+++ b/chash.js
@@ -106,7 +106,7 @@ function buffer2bin(buf){
 
 function bin2buffer(bin){
 	var len = bin.length/8;
-	var buf = new Buffer(len);
+	var buf = new Buffer.alloc(len);
 	for (var i=0; i<len; i++)
 		buf[i] = parseInt(bin.substr(i*8, 8), 2);
 	return buf;
@@ -115,7 +115,7 @@ function bin2buffer(bin){
 function getChecksum(clean_data){
 	var full_checksum = crypto.createHash("sha256").update(clean_data).digest();
 	//console.log(full_checksum);
-	var checksum = new Buffer([full_checksum[5], full_checksum[13], full_checksum[21], full_checksum[29]]);
+	var checksum = new Buffer.from([full_checksum[5], full_checksum[13], full_checksum[21], full_checksum[29]]);
 	return checksum;
 }
 
@@ -154,7 +154,7 @@ function isChashValid(encoded){
 	if (encoded_len !== 32 && encoded_len !== 48) // 160/5 = 32, 288/6 = 48
 		throw Error("wrong encoded length: "+encoded_len);
 	try{
-		var chash = (encoded_len === 32) ? base32.decode(encoded) : new Buffer(encoded, 'base64');
+		var chash = (encoded_len === 32) ? base32.decode(encoded) : new Buffer.from(encoded, 'base64');
 	}
 	catch(e){
 		console.log(e);

--- a/device.js
+++ b/device.js
@@ -120,7 +120,7 @@ function setDeviceHub(device_hub){
 }
 
 function isValidPubKey(b64_pubkey){
-	return ecdsa.publicKeyVerify(new Buffer(b64_pubkey, 'base64'));
+	return ecdsa.publicKeyVerify(new Buffer.from(b64_pubkey, 'base64'));
 }
 
 // -------------------------
@@ -318,11 +318,11 @@ function decryptPackage(objEncryptedPackage){
 		ecdh.generateKeys("base64", "compressed");
 	ecdh.setPrivateKey(priv_key);
 	var shared_secret = deriveSharedSecret(ecdh, objEncryptedPackage.dh.sender_ephemeral_pubkey);
-	var iv = new Buffer(objEncryptedPackage.iv, 'base64');
+	var iv = new Buffer.from(objEncryptedPackage.iv, 'base64');
 	var decipher = crypto.createDecipheriv('aes-128-gcm', shared_secret, iv);
-	var authtag = new Buffer(objEncryptedPackage.authtag, 'base64');
+	var authtag = new Buffer.from(objEncryptedPackage.authtag, 'base64');
 	decipher.setAuthTag(authtag);
-	var enc_buf = Buffer(objEncryptedPackage.encrypted_message, "base64");
+	var enc_buf = Buffer.from(objEncryptedPackage.encrypted_message, "base64");
 //	var decrypted1 = decipher.update(enc_buf);
 	// under browserify, decryption of long buffers fails with Array buffer allocation errors, have to split the buffer into chunks
 	var arrChunks = [];

--- a/private_profile.js
+++ b/private_profile.js
@@ -17,7 +17,7 @@ returns objPrivateProfile {
 }
 */
 function getPrivateProfileFromJsonBase64(privateProfileJsonBase64){
-	var privateProfileJson = Buffer(privateProfileJsonBase64, 'base64').toString('utf8');
+	var privateProfileJson = Buffer.from(privateProfileJsonBase64, 'base64').toString('utf8');
 	console.log(privateProfileJson);
 	try{
 		var objPrivateProfile = JSON.parse(privateProfileJson);

--- a/signature.js
+++ b/signature.js
@@ -11,8 +11,8 @@ exports.sign = function(hash, priv_key){
 
 exports.verify = function(hash, b64_sig, b64_pub_key){
 	try{
-		var signature = new Buffer(b64_sig, "base64"); // 64 bytes (32+32)
-		return ecdsa.verify(hash, signature, new Buffer(b64_pub_key, "base64"));
+		var signature = new Buffer.from(b64_sig, "base64"); // 64 bytes (32+32)
+		return ecdsa.verify(hash, signature, new Buffer.from(b64_pub_key, "base64"));
 	}
 	catch(e){
 		console.log('signature verification exception: '+e.toString());

--- a/validation_utils.js
+++ b/validation_utils.js
@@ -78,12 +78,12 @@ function isNonemptyObject(obj){
 }
 
 function isValidBase64(b64, len){
-	return (typeof b64 === "string" && (!len || b64.length === len) && b64 === (new Buffer(b64, "base64")).toString("base64"));
+	return (typeof b64 === "string" && (!len || b64.length === len) && b64 === (new Buffer.from(b64, "base64")).toString("base64"));
 }
 
 function isValidHexadecimal(hex, len){
 	try {
-		return (typeof hex === "string" && (!len || hex.length === len) && hex === (new Buffer(hex, "hex")).toString("hex"));
+		return (typeof hex === "string" && (!len || hex.length === len) && hex === (new Buffer.from(hex, "hex")).toString("hex"));
 	}
 	catch (e) {
 		return false;


### PR DESCRIPTION
This warning appears on Node v10 and above: `(node:1) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.`

Buffer.alloc() and Buffer.from() has been since Node v4.