### PR TITLE
added support for connecting via HTTP proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Whether your node wants to learn about new peers from its current peers (`true`,
 
 Settings for connecting through optional SOCKS5 proxy.  Use them to connect through TOR and hide your IP address from peers even when making outgoing connections.  This is useful and highly recommended when you are running an online wallet on your server and want to make it harder for potential attackers to learn the IP address of the target to attack.  Set `socksLocalDNS` to `false` to route DNS queries through TOR as well.
 
+#### conf.httpsProxy
+
+Setting for connecting through an optional HTTPS proxy. Use it when your local network can only access the Internet via an http proxy server. When both socks5 and http proxy are set, socks5 takes precedence. The configuration value is the full URL to the proxy server, eg. `http://proxy:3128`
+
 #### conf.smtpTransport, conf.smtpRelay, conf.smtpPort, conf.smtpUser, and conf.smtpPassword
 
 Settings for sending email. They are used e.g. if your node needs to send notifications. `smtpTransport` can take one of three values:

--- a/conf.js
+++ b/conf.js
@@ -46,6 +46,9 @@ exports.port = null;
 // For better security you should not use local DNS with socks proxy
 // exports.socksLocalDNS = false;
 
+// Connects through an http proxy server
+// exports.httpsProxy = 'http://proxy:3128'
+
 // WebSocket protocol prefixed to all hosts.  Must be wss:// on livenet, ws:// is allowed on testnet
 exports.WS_PROTOCOL = process.env.devnet ? "ws://" : "wss://";
 

--- a/network.js
+++ b/network.js
@@ -3,6 +3,7 @@
 var bCordova = (typeof window === 'object' && window && window.cordova);
 var WebSocket = bCordova ? global.WebSocket : require('ws');
 var socks = bCordova ? null : require('socks');
+var HttpsProxyAgent = bCordova ? null : require('https-proxy-agent');
 var WebSocketServer = WebSocket.Server;
 var crypto = require('crypto');
 var _ = require('lodash');
@@ -415,7 +416,11 @@ function connectToPeer(url, onOpen) {
 		console.log('Using socksPort: ' + conf.socksPort);
 		console.log('Using socksUsername: ' + typeof conf.socksUsername === 'undefined' ? "dummy" : conf.socksUsername);
 		console.log('Using socksPassword: ' + typeof conf.socksPassword === 'undefined' ? "dummy" : conf.socksPassword);
+	} else if (HttpsProxyAgent && conf.httpsProxy) {
+		options.agent = new HttpsProxyAgent(conf.httpsProxy);
+		console.log('Using httpsProxy: ' + conf.httpsProxy);
 	}
+
 	var ws = options.agent ? new WebSocket(url,options) : new WebSocket(url);
 	assocConnectingOutboundWebsockets[url] = ws;
 	setTimeout(function(){

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "decimal.js": "^10.0.2",
     "bitcore-mnemonic": "~1.0.0",
     "dotenv": "5.0.1",
+    "https-proxy-agent": "^5.0.0",
     "jszip": "^3.1.3",
     "level-rocksdb": "^5",
     "lodash": "^4.6.1",


### PR DESCRIPTION
This PR allows connecting a wallet to the hub and peers via an http proxy server. Some stricter local networks might not allow connecting to the internet via a socks proxy and the only option might be an http proxy.

I wrote a test, but since it's more like an integration test that requires external systems like a proxy server and also hard to run it isolated or without side-effect, I have not added it to the PR, but for reference, I used the below test script. For proxy I used a docker container:
```bash
docker run --name squid --rm -d -p 3128:3128 ubuntu/squid
```

```javascript
const test = require("ava");
const conf = require("../conf")
const network = require("../network");

async function connect(url) {
	return new Promise( (resolve, reject) => {
		network.findOutboundPeerOrConnect(url, (error, ws) => {
			if (error) return reject(error);
			resolve(ws);
		});
	});
}

test("Connects via http proxy", async (assert) => {
	conf.httpsProxy="http://localhost:3128"

	let ws = await connect("wss://obyte.org/bb")

	assert.truthy(ws)
	assert.true(ws.url === "wss://obyte.org/bb")
	assert.true(ws.bOutbound)
});
```