### PR TITLE
cross-platform test setup and ci without yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: yarn install
+      - run: npm install
 
       - save_cache:
           paths:
@@ -29,4 +29,4 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       # run tests!
-      - run: yarn ava --timeout=60s --concurrency=1
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18.x, 20.x]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: use node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: install dependencies
+        run: npm install
+
+      - name: run tests
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ws": "^8.18.1"
   },
   "scripts": {
-    "test": "yarn ava --timeout=60s --concurrency=1 --fail-fast --verbose",
+    "test": "npx ava --timeout=60s --concurrency=1 --fail-fast --verbose",
     "compileGrammar:oscript": "nearleyc ./formula/grammars/oscript.ne -o ./formula/grammars/oscript.js",
     "compileGrammar:ojson": "nearleyc ./formula/grammars/ojson.ne -o ./formula/grammars/ojson.js"
   },

--- a/test/_testdata_fs.js
+++ b/test/_testdata_fs.js
@@ -1,0 +1,22 @@
+/*jslint node: true */
+"use strict";
+var fs = require("fs");
+
+/**
+ * Remove a test data directory (cross-platform; replaces rm -rf).
+ */
+function removeTestdataDir(dir) {
+	fs.rmSync(dir, { recursive: true, force: true });
+}
+
+/**
+ * Copy a test data tree (cross-platform; replaces cp -r). Requires Node 16.7+.
+ */
+function copyTestdataDir(src, dest) {
+	fs.cpSync(src, dest, { recursive: true });
+}
+
+module.exports = {
+	removeTestdataDir: removeTestdataDir,
+	copyTestdataDir: copyTestdataDir
+};

--- a/test/aa.test.js
+++ b/test/aa.test.js
@@ -1,5 +1,5 @@
-var shell = require('child_process').execSync;
 var path = require('path');
+var testdataFs = require('./_testdata_fs.js');
 var fs = require('fs');
 var async = require('async');
 var crypto = require('crypto');
@@ -17,7 +17,7 @@ desktop_app.getAppDataDir = function() { return __dirname + '/.testdata-' + path
 
 // cleanup, if last time failed
 var dst_dir = __dirname + '/.testdata-' + path.basename(__filename);
-shell('rm -rf ' + dst_dir);
+testdataFs.removeTestdataDir(dst_dir);
 
 var Decimal = require('decimal.js');
 var formulaParser = require('../formula/index');

--- a/test/aa_composer.test.js
+++ b/test/aa_composer.test.js
@@ -1,6 +1,6 @@
 var path = require('path');
-var shell = require('child_process').execSync;
 var _ = require('lodash');
+var testdataFs = require('./_testdata_fs.js');
 
 process.env.devnet = 1;
 var constants = require("../constants.js");
@@ -10,9 +10,8 @@ desktop_app.getAppDataDir = function () { return __dirname + '/.testdata-' + pat
 
 var src_dir = __dirname + '/initial-testdata-' + path.basename(__filename);
 var dst_dir = __dirname + '/.testdata-' + path.basename(__filename);
-//shell('mkdir ' + dst_dir);
-shell('rm -rf ' + dst_dir);
-shell('cp -r ' + src_dir + '/ ' + dst_dir);
+testdataFs.removeTestdataDir(dst_dir);
+testdataFs.copyTestdataDir(src_dir, dst_dir);
 
 var db = require('../db.js');
 var aa_validation = require('../aa_validation.js');

--- a/test/formula.test.js
+++ b/test/formula.test.js
@@ -1,5 +1,5 @@
-var shell = require('child_process').execSync;
 var path = require('path');
+var testdataFs = require('./_testdata_fs.js');
 var crypto = require('crypto');
 var Mnemonic = require('bitcore-mnemonic');
 
@@ -17,7 +17,7 @@ desktop_app.getAppDataDir = function() { return __dirname + '/.testdata-' + path
 
 // cleanup, if last time failed
 var dst_dir = __dirname + '/.testdata-' + path.basename(__filename);
-shell('rm -rf ' + dst_dir);
+testdataFs.removeTestdataDir(dst_dir);
 
 var Decimal = require('decimal.js');
 var formulaParser = require('../formula/index');

--- a/test/formulas_in_contracts.test.js
+++ b/test/formulas_in_contracts.test.js
@@ -1,11 +1,11 @@
-var shell = require('child_process').execSync;
 var path = require('path');
+var testdataFs = require('./_testdata_fs.js');
 var desktop_app = require('../desktop_app.js');
 desktop_app.getAppDataDir = function() { return __dirname + '/.testdata-' + path.basename(__filename); }
 
 // cleanup, if last time failed
 var dst_dir = __dirname + '/.testdata-' + path.basename(__filename);
-shell('rm -rf ' + dst_dir);
+testdataFs.removeTestdataDir(dst_dir);
 
 var definition = require("../definition");
 var formulaParser = require("../formula/index");

--- a/test/pem_sig.test.js
+++ b/test/pem_sig.test.js
@@ -1,12 +1,12 @@
-var shell = require('child_process').execSync;
 var path = require('path');
+var testdataFs = require('./_testdata_fs.js');
 var asymSig = require('../signature.js');
 var desktop_app = require('../desktop_app.js');
 desktop_app.getAppDataDir = function() { return __dirname + '/.testdata-' + path.basename(__filename); }
 
 // cleanup, if last time failed
 var dst_dir = __dirname + '/.testdata-' + path.basename(__filename);
-shell('rm -rf ' + dst_dir);
+testdataFs.removeTestdataDir(dst_dir);
 
 var formulaParser = require('../formula/index');
 var test = require('ava');


### PR DESCRIPTION
## summary

Several tests wiped and copied fixture dirs with `rm -rf` and `cp -r`, which breaks on Windows (and any environment without Unix shell). This adds a tiny helper using `fs.rmSync` / `fs.cpSync` so the same setup runs on Linux, macOS, and Windows.

The `npm test` script no longer shells out to `yarn`, so contributors only need Node and npm. CircleCI is switched to `npm install` / `npm test` for the same reason.

GitHub Actions runs the suite on Ubuntu against Node 18 and 20 so regressions are caught on PRs and pushes to `master` / `main`.

Contribution prepared by mooncitydev.