### PR TITLE
fix: add parameterized queries in divisible_asset.js

### DIFF
--- a/divisible_asset.js
+++ b/divisible_asset.js
@@ -50,8 +50,8 @@ function validateAndSaveDivisiblePrivatePayment(conn, objPrivateElement, callbac
 						address = arrAuthorAddresses[0];
 					else
 						address_sql = "(SELECT address FROM outputs \
-							WHERE unit="+conn.escape(src_unit)+" AND message_index="+src_message_index+" \
-								AND output_index="+src_output_index+" AND address IN("+conn.escape(arrAuthorAddresses)+"))";
+						WHERE unit="+conn.escape(src_unit)+" AND message_index="+conn.escape(src_message_index)+" \
+							AND output_index="+conn.escape(src_output_index)+" AND address IN("+conn.escape(arrAuthorAddresses)+"))";
 				}
 				var is_unique = bStable ? 1 : null; // unstable still have chances to become nonserial therefore nonunique
 				conn.addQuery(arrQueries, "INSERT INTO inputs \n\


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `divisible_asset.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `divisible_asset.js:50` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-89 |

**Description**: The `address_sql` variable is constructed using string concatenation with `src_message_index` and `src_output_index` values interpolated directly without escaping or parameterization. These values originate from external payment data, creating a SQL injection vector.

## Evidence

**Exploitation scenario**: An attacker crafts a malicious private payment element where `input.message_index` or `input.output_index` contains SQL injection payload.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `divisible_asset.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
